### PR TITLE
Introduced the support for AES256 server-side encryption

### DIFF
--- a/src/main/java/com/upplication/s3fs/AmazonS3Client.java
+++ b/src/main/java/com/upplication/s3fs/AmazonS3Client.java
@@ -55,6 +55,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 
 import java.io.File;
@@ -115,6 +116,13 @@ public class AmazonS3Client {
 			String destinationKey) {
 		return client.copyObject(sourceBucketName, sourceKey, destinationBucketName, destinationKey);
 	}
+	/**
+	 * @see com.amazonaws.services.s3.AmazonS3Client#copyObject(CopyObjectRequest)
+	 */
+	public CopyObjectResult copyObject(CopyObjectRequest copyObjectRequest) {
+		return client.copyObject(copyObjectRequest);
+	}
+
 	/**
 	 * @see com.amazonaws.services.s3.AmazonS3Client#getBucketAcl(String)
 	 */

--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -333,7 +333,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
 				.setChunkSize(props.getProperty("upload_chunk_size"))
 				.setStorageClass(props.getProperty("upload_storage_class"))
 				.setMaxAttempts(props.getProperty("upload_max_attempts"))
-				.setRetrySleep(props.getProperty("upload_retry_sleep"));
+				.setRetrySleep(props.getProperty("upload_retry_sleep"))
+                .setStorageEncryption(props.getProperty("storage_encryption"));
 
 		return new S3OutputStream(s3,req);
 	}

--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -532,11 +532,9 @@ public class S3FileSystemProvider extends FileSystemProvider {
         CopyObjectRequest copyObjRequest = new CopyObjectRequest(s3Source.getBucket(), s3Source.getKey(),s3Target.getBucket(), s3Target.getKey());
         ObjectMetadata sourceObjMetadata = s3Source.getFileSystem().getClient().getObjectMetadata(s3Source.getBucket(), s3Source.getKey());
         if (sourceObjMetadata.getSSEAlgorithm()!= null) {
-            if (sourceObjMetadata.getSSEAlgorithm().equals("AES256")) {
-               ObjectMetadata targetObjectMetadata = new ObjectMetadata();
-               targetObjectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
-               copyObjRequest.setNewObjectMetadata(targetObjectMetadata);
-            }
+            ObjectMetadata targetObjectMetadata = new ObjectMetadata();
+            targetObjectMetadata.setSSEAlgorithm(sourceObjMetadata.getSSEAlgorithm());
+            copyObjRequest.setNewObjectMetadata(targetObjectMetadata);
         } 
 		s3Source.getFileSystem()
 				.getClient()

--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -531,10 +531,12 @@ public class S3FileSystemProvider extends FileSystemProvider {
 		}
         CopyObjectRequest copyObjRequest = new CopyObjectRequest(s3Source.getBucket(), s3Source.getKey(),s3Target.getBucket(), s3Target.getKey());
         ObjectMetadata sourceObjMetadata = s3Source.getFileSystem().getClient().getObjectMetadata(s3Source.getBucket(), s3Source.getKey());
-        if (sourceObjMetadata.getSSEAlgorithm().equals("AES256")) {
-           ObjectMetadata targetObjectMetadata = new ObjectMetadata();
-           targetObjectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
-           copyObjRequest.setNewObjectMetadata(targetObjectMetadata);
+        if (sourceObjMetadata.getSSEAlgorithm()!= null) {
+            if (sourceObjMetadata.getSSEAlgorithm().equals("AES256")) {
+               ObjectMetadata targetObjectMetadata = new ObjectMetadata();
+               targetObjectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+               copyObjRequest.setNewObjectMetadata(targetObjectMetadata);
+            }
         } 
 		s3Source.getFileSystem()
 				.getClient()

--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -56,6 +56,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.Permission;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -527,11 +529,16 @@ public class S3FileSystemProvider extends FileSystemProvider {
 						"target already exists: %s", target));
 			}
 		}
-
+        CopyObjectRequest copyObjRequest = new CopyObjectRequest(s3Source.getBucket(), s3Source.getKey(),s3Target.getBucket(), s3Target.getKey());
+        ObjectMetadata sourceObjMetadata = s3Source.getFileSystem().getClient().getObjectMetadata(s3Source.getBucket(), s3Source.getKey());
+        if (sourceObjMetadata.getSSEAlgorithm().equals("AES256")) {
+           ObjectMetadata targetObjectMetadata = new ObjectMetadata();
+           targetObjectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+           copyObjRequest.setNewObjectMetadata(targetObjectMetadata);
+        } 
 		s3Source.getFileSystem()
 				.getClient()
-				.copyObject(s3Source.getBucket(), s3Source.getKey(),
-						s3Target.getBucket(), s3Target.getKey());
+				.copyObject(copyObjRequest);
 	}
 
 	@Override

--- a/src/main/java/com/upplication/s3fs/S3OutputStream.java
+++ b/src/main/java/com/upplication/s3fs/S3OutputStream.java
@@ -142,6 +142,22 @@ public final class S3OutputStream extends OutputStream {
             return this;
         }
 
+        
+        public S3UploadRequest setStorageEncryption(String storageEncryption) {
+            if( storageEncryption == null) {
+                return this;
+            }
+            else if (storageEncryption != "AES256") {
+                log.warn("Not a valid S3 server-side encryption type: `{}` -- Currently only AES256 is supported",storageEncryption);
+            }
+            else {
+                ObjectMetadata objectMetadata = new ObjectMetadata();
+                objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+                this.setMetadata(objectMetadata);
+            }
+            return this;
+        }
+
         public S3UploadRequest setMetadata(ObjectMetadata metadata) {
             this.metadata = metadata;
             return this;

--- a/src/main/java/com/upplication/s3fs/S3Path.java
+++ b/src/main/java/com/upplication/s3fs/S3Path.java
@@ -21,7 +21,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014 Javier Arnáiz @arnaix
+ * Copyright (c) 2014 Javier Arnaiz @arnaix
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -61,7 +61,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2014 Javier Arnáiz @arnaix
+# Copyright (c) 2014 Javier Arnaiz @arnaix
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I have introduced changes into the S3FileSystemProvider and S3OutputStream classes to support server-side encryption.

In particular:

- A new method ```setStorageEncryption``` has been created in the S3OutputStream class to read the configuration options and, if specified, apply AES256 encryption to every new file that is uploaded on S3.

- The ```copy``` method in the S3FileSystemProvider class has been updated to use CopyObjectRequest to define encryption for the target object, if the source object is encrypted. By default, the AWS JDK method copyObject does not transfer encryption information (http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#copyObject-com.amazonaws.services.s3.model.CopyObjectRequest-) so apparently this needs to be managed explicitly.

Tests are also provided, please consider that some previous tests for FileSystemProvider#copy method are returning an error, since they use mock-ups for S3 connection and the new method requires real objects on S3 to retrieve the meta-data information (maybe those tests could be suppressed or modified). Other tests in the suite also seem to fail, but at least for what I have been able to check, these errors are not related to the changes in this pull request.