### PR TITLE
Add signer override

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -737,6 +737,11 @@ public class S3FileSystemProvider extends FileSystemProvider {
 			config.setProxyWorkstation(props.getProperty("proxy_workstation"));
 		}
 
+		if ( props.containsKey("signer_override")) {
+			log.debug("AWS client config - signerOverride: {}", props.getProperty("signer_override"));
+			config.setSignerOverride(props.getProperty("signer_override"));
+		}
+
 		if( props.containsKey("socket_send_buffer_size_hints") || props.containsKey("socket_recv_buffer_size_hints") ) {
 			log.trace("AWS client config - socket_send_buffer_size_hints: {}, socket_recv_buffer_size_hints: {}", props.getProperty("socket_send_buffer_size_hints","0"), props.getProperty("socket_recv_buffer_size_hints", "0"));
 			int send = Integer.parseInt(props.getProperty("socket_send_buffer_size_hints","0"));

--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -778,7 +778,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
 			client = new AmazonS3Client(new com.amazonaws.services.s3.AmazonS3Client(config));
 		} else {
 			AWSCredentials credentials = new BasicAWSCredentials(accessKey.toString(), secretKey.toString());
-			client = new AmazonS3Client(new com.amazonaws.services.s3.AmazonS3Client(credentials));
+			client = new AmazonS3Client(new com.amazonaws.services.s3.AmazonS3Client(credentials,config));
 		}
 
 		if (uri.getHost() != null) {

--- a/src/main/java/com/upplication/s3fs/S3OutputStream.java
+++ b/src/main/java/com/upplication/s3fs/S3OutputStream.java
@@ -61,7 +61,7 @@ import static java.util.Objects.requireNonNull;
  * Parallel S3 multipart uploader. Based on the following code request
  * See https://github.com/Upplication/Amazon-S3-FileSystem-NIO2/pulls
  *
- * @Paolo Di Tommaso
+ * @author Paolo Di Tommaso
  * @author Tom Wieczorek
  */
 

--- a/src/main/java/com/upplication/s3fs/util/ByteBufferInputStream.java
+++ b/src/main/java/com/upplication/s3fs/util/ByteBufferInputStream.java
@@ -21,7 +21,7 @@
 package com.upplication.s3fs.util;
 
 /**
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Paolo Di Tommaso paolo.ditommaso@gmail.com
  */
 
 import java.io.IOException;
@@ -33,7 +33,7 @@ import java.nio.ByteBuffer;
  *
  * See http://stackoverflow.com/a/6603018/395921
  *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Paolo Di Tommaso paolo.ditommaso@gmail.com
  */
 public class ByteBufferInputStream extends InputStream {
 


### PR DESCRIPTION
Add signer override option, in order to support s3 servers that do not support the default aws4 signing, see https://github.com/aws/aws-sdk-java/issues/372. Tested with our local ceph-radowgw installation. 