### PR TITLE
Add path style access option for non-aws S3 storage service provider

### DIFF
--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -789,9 +789,9 @@ public class S3FileSystemProvider extends FileSystemProvider {
 			client = new AmazonS3Client(new com.amazonaws.services.s3.AmazonS3Client(credentials,config));
 		}
 
-		if (props.getProperty("path_style_access") != null) {
+		if (props.getProperty("s_3_path_style_access") != null) {
 			S3ClientOptions options = S3ClientOptions.builder()
-					.setPathStyleAccess(Boolean.parseBoolean(props.getProperty("path_style_access")))
+					.setPathStyleAccess(Boolean.parseBoolean(props.getProperty("s_3_path_style_access")))
 					.build();
 			client.client.setS3ClientOptions(options);
 		}

--- a/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/com/upplication/s3fs/S3FileSystemProvider.java
@@ -49,6 +49,7 @@ import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
@@ -786,6 +787,13 @@ public class S3FileSystemProvider extends FileSystemProvider {
 		} else {
 			AWSCredentials credentials = new BasicAWSCredentials(accessKey.toString(), secretKey.toString());
 			client = new AmazonS3Client(new com.amazonaws.services.s3.AmazonS3Client(credentials,config));
+		}
+
+		if (props.getProperty("path_style_access") != null) {
+			S3ClientOptions options = S3ClientOptions.builder()
+					.setPathStyleAccess(Boolean.parseBoolean(props.getProperty("path_style_access")))
+					.build();
+			client.client.setS3ClientOptions(options);
 		}
 
 		if (uri.getHost() != null) {


### PR DESCRIPTION
@pditommaso Could you please have look as this?
For now, the nextflow-s3fs only supported domain-based S3 storage. There is no way to make it work with non-aws S3 storage providers that using path style access. This pull request adds an option to make it work with those providers.

According to [S3 for java library](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/S3ClientOptions.html#isPathStyleAccess--)

> Amazon S3 supports virtual-hosted-style and path-style access in all Regions. The path-style syntax, however, requires that you use the region-specific endpoint when attempting to access a bucket.



```
aws {
      client {
        s3PathStyleAccess = 'true'        
      }
    }
```